### PR TITLE
Added X-Requested-With header to XMLHttpRequest

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -117,6 +117,7 @@
                                 let request = new XMLHttpRequest();
                                 request.addEventListener("load", this.onAjaxResponse);
                                 request.open("GET", options.bodyUrl);
+                                request.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
                                 request.send();
                             }
                         }


### PR DESCRIPTION
Having a "X-Requested-With" header on the XMLHttpRequest will assist back end framework(s) detect AJAX request.